### PR TITLE
Modernize CRM theme styling for Vaadin/Jmix UI

### DIFF
--- a/src/main/frontend/themes/crm/colors.css
+++ b/src/main/frontend/themes/crm/colors.css
@@ -1,11 +1,28 @@
 /* custom theme colors*/
 html {
-    --lumo-primary-color: rgb(0, 106, 245);
+    --lumo-primary-color: hsl(217, 92%, 56%);
+    --lumo-primary-color-50pct: hsla(217, 92%, 56%, 0.5);
+    --lumo-primary-color-10pct: hsla(217, 92%, 56%, 0.12);
+    --lumo-primary-text-color: hsl(217, 90%, 46%);
+
+    --lumo-body-text-color: hsl(216, 27%, 18%);
+    --lumo-secondary-text-color: hsl(217, 12%, 40%);
+
+    --lumo-base-color: hsl(220, 20%, 99%);
+    --lumo-tint-5pct: hsla(220, 55%, 15%, 0.03);
+    --lumo-tint-10pct: hsla(220, 55%, 15%, 0.06);
+
+    --crm-surface-color: hsl(0, 0%, 100%);
+    --crm-soft-border-color: hsla(217, 28%, 22%, 0.11);
+    --crm-elevation-shadow: 0 8px 28px hsla(220, 40%, 2%, 0.08);
 }
 
 [theme~="dark"] {
-    --lumo-primary-color: rgb(0, 106, 245);
-    --lumo-base-color: hsl(214, 14%, 10%);
+    --lumo-primary-color: hsl(217, 100%, 68%);
+    --lumo-primary-color-50pct: hsla(217, 100%, 68%, 0.5);
+    --lumo-primary-color-10pct: hsla(217, 100%, 68%, 0.16);
+    --lumo-primary-text-color: hsl(217, 96%, 74%);
+    --lumo-base-color: hsl(215, 21%, 10%);
 
     --lumo-shade-5pct: rgba(27, 37, 50, 0.05);
     --lumo-shade-10pct: rgba(27, 37, 50, 0.1);
@@ -17,7 +34,11 @@ html {
     --lumo-shade-70pct: rgba(27, 37, 50, 0.7);
     --lumo-shade-80pct: rgba(27, 37, 50, 0.8);
     --lumo-shade-90pct: rgba(27, 37, 50, 0.9);
-    --lumo-shade: hsl(214, 30%, 15%);
+    --lumo-shade: hsl(214, 35%, 15%);
+
+    --crm-surface-color: hsl(216, 26%, 14%);
+    --crm-soft-border-color: hsla(216, 35%, 74%, 0.2);
+    --crm-elevation-shadow: 0 10px 30px hsla(220, 30%, 2%, 0.45);
 
     --lumo-success-text-color: rgb(49, 221, 121);
     --lumo-success-color-50pct: rgba(31, 193, 99, 0.5);

--- a/src/main/frontend/themes/crm/crm.css
+++ b/src/main/frontend/themes/crm/crm.css
@@ -1,11 +1,29 @@
 html {
     --lumo-clickable-cursor: pointer;
 
-    --lumo-line-height-m: 1.4;
-    --lumo-line-height-s: 1.2;
+    --lumo-line-height-m: 1.45;
+    --lumo-line-height-s: 1.25;
     --lumo-line-height-xs: 1.1;
 
-    --lumo-border-radius: 0.5em;
+    --lumo-border-radius: 0.75em;
+    --lumo-border-radius-s: 0.5em;
+    --lumo-border-radius-m: 0.75em;
+    --lumo-border-radius-l: 1em;
+
+    --lumo-font-family: Inter, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+
+    --lumo-space-xs: 0.375rem;
+    --lumo-space-s: 0.625rem;
+    --lumo-space-m: 1rem;
+    --lumo-space-l: 1.5rem;
+
+    --lumo-box-shadow-xs: 0 1px 2px hsla(220, 35%, 15%, 0.08);
+    --lumo-box-shadow-s: 0 3px 12px hsla(220, 35%, 15%, 0.1);
+    --lumo-box-shadow-m: var(--crm-elevation-shadow);
+}
+
+body {
+    background: linear-gradient(180deg, var(--lumo-tint-5pct) 0%, transparent 40%) var(--lumo-base-color);
 }
 
 .clickable {

--- a/src/main/frontend/themes/crm/view/login-view.css
+++ b/src/main/frontend/themes/crm/view/login-view.css
@@ -2,22 +2,25 @@
 
 .login-form-wrapper {
     max-width: calc(var(--lumo-size-m) * 12);
-    background: transparent;
+    background: color-mix(in srgb, var(--crm-surface-color) 92%, transparent);
     padding: var(--lumo-space-l);
-    border-radius: var(--lumo-border-radius-m);
+    border-radius: var(--lumo-border-radius-l);
+    border: 1px solid var(--crm-soft-border-color);
+    box-shadow: var(--lumo-box-shadow-m);
     align-items: stretch;
+    backdrop-filter: blur(10px);
 }
 
 .login-form-wrapper > * {
-    --vaadin-checkbox-label-color: white;
-    --vaadin-checkbox-background: white;
-    --vaadin-selection-color: black;
+    --vaadin-checkbox-label-color: var(--lumo-body-text-color);
+    --vaadin-checkbox-background: var(--crm-surface-color);
+    --vaadin-selection-color: var(--lumo-primary-color);
 
-    --vaadin-input-field-value-color: black;
-    --vaadin-input-field-background: white;
-    --vaadin-input-field-label-color: #D1CFCFFF;
-    --vaadin-input-field-focused-label-color: white;
-    --vaadin-input-field-hovered-label-color: white;
+    --vaadin-input-field-value-color: var(--lumo-body-text-color);
+    --vaadin-input-field-background: var(--crm-surface-color);
+    --vaadin-input-field-label-color: var(--lumo-secondary-text-color);
+    --vaadin-input-field-focused-label-color: var(--lumo-primary-text-color);
+    --vaadin-input-field-hovered-label-color: var(--lumo-body-text-color);
 }
 
 .login-form-error-message {
@@ -66,13 +69,13 @@
 }
 
 .login-form-submit {
-    color: var(--vaadin-input-field-background);
-    background-color: var(--vaadin-input-field-value-color);
+    color: var(--lumo-primary-contrast-color);
+    background: linear-gradient(120deg, var(--lumo-primary-color), color-mix(in srgb, var(--lumo-primary-color) 70%, white));
 }
 
 .login-view-layout {
     padding: 0;
-    background: white;
+    background: radial-gradient(circle at 20% 0%, var(--lumo-primary-color-10pct), transparent 35%), var(--lumo-base-color);
     min-height: 100vh;
     height: 100%;
     width: 100%;
@@ -88,7 +91,7 @@
 
 .login-panel {
     flex: 0 0 clamp(360px, 36vw, 520px);
-    background: var(--lumo-primary-color);
+    background: linear-gradient(160deg, color-mix(in srgb, var(--lumo-primary-color) 88%, black), color-mix(in srgb, var(--lumo-primary-color) 70%, black));
     display: flex;
     flex-direction: column;
     justify-content: center;

--- a/src/main/frontend/themes/crm/view/main-view.css
+++ b/src/main/frontend/themes/crm/view/main-view.css
@@ -5,6 +5,10 @@
   height: var(--lumo-size-xl);
   align-items: center;
   width: 100%;
+  padding-inline: var(--lumo-space-s);
+  backdrop-filter: blur(12px);
+  background-color: color-mix(in srgb, var(--crm-surface-color) 82%, transparent);
+  border-bottom: 1px solid var(--crm-soft-border-color);
 }
 
 .jmix-main-view-drawer-toggle {
@@ -28,18 +32,21 @@
   display: flex;
   align-items: center;
   height: var(--lumo-size-xl);
-  margin: 0;
-  padding-left: var(--lumo-space-m);
-  padding-right: var(--lumo-space-m);
+  margin: var(--lumo-space-s);
+  padding-inline: var(--lumo-space-m);
   font-size: var(--lumo-font-size-m);
+  border-radius: var(--lumo-border-radius-l);
+  background: linear-gradient(135deg, var(--lumo-primary-color), color-mix(in srgb, var(--lumo-primary-color) 75%, white));
+  color: var(--lumo-primary-contrast-color);
+  box-shadow: var(--lumo-box-shadow-s);
 }
 
 .jmix-main-view-application-title:hover * {
-    filter: brightness(1.2);
+  filter: brightness(1.06);
 }
 
 .jmix-main-view-application-title-base-link {
-  color: var(--lumo-header-text-color);
+  color: inherit;
   cursor: pointer;
 }
 
@@ -50,19 +57,23 @@
 .jmix-main-view-navigation {
   display: flex;
   flex-direction: column;
-  border-bottom: 1px solid;
-  border-color: var(--lumo-contrast-10pct);
+  border-bottom: 1px solid var(--crm-soft-border-color);
   flex-grow: 1;
   overflow: auto;
+  padding: var(--lumo-space-s);
+  gap: 0.25rem;
 }
 
 .jmix-main-view-footer {
   display: flex;
   align-items: center;
-  margin-bottom: var(--lumo-space-s);
-  margin-top: var(--lumo-space-s);
-  padding: var(--lumo-space-xs) var(--lumo-space-m);
-  gap: var(--lumo-space-m);
+  margin: var(--lumo-space-s);
+  padding: var(--lumo-space-xs) var(--lumo-space-s);
+  border-radius: var(--lumo-border-radius-l);
+  border: 1px solid var(--crm-soft-border-color);
+  background-color: var(--crm-surface-color);
+  box-shadow: var(--lumo-box-shadow-xs);
+  gap: var(--lumo-space-s);
 }
 
 .jmix-main-view-footer .jmix-user-indicator {
@@ -70,147 +81,143 @@
 }
 
 .jmix-main-view-footer :is(.jmix-user-menu-button-content, .user-menu-button-content) {
-    width: calc(var(--vaadin-app-layout-drawer-width, 16em) - var(--lumo-space-m) * 2);
+  width: calc(var(--vaadin-app-layout-drawer-width, 16em) - var(--lumo-space-m) * 2);
 }
 
 .user-menu-button-content,
 .user-menu-header-content {
-    display: grid;
-    grid-template: "avatar text"
-                   "avatar subtext";
-    grid-template-columns: auto 1fr;
-    column-gap: var(--lumo-space-s);
-
-    width: max-content;
-    box-sizing: border-box;
-
-    color: var(--lumo-body-text-color);
-    padding: var(--lumo-space-xs) var(--lumo-space-s);
+  display: grid;
+  grid-template: "avatar text"
+                 "avatar subtext";
+  grid-template-columns: auto 1fr;
+  column-gap: var(--lumo-space-s);
+  width: max-content;
+  box-sizing: border-box;
+  color: var(--lumo-body-text-color);
+  padding: var(--lumo-space-xs) var(--lumo-space-s);
 }
 
 .user-menu-header-content {
-    width: 100%;
-    padding-inline-end: var(--lumo-space-l);
+  width: 100%;
+  padding-inline-end: var(--lumo-space-l);
 }
 
 .user-menu-button-content > .user-menu-avatar,
 .user-menu-header-content > .user-menu-avatar {
-    grid-area: avatar;
-    align-self: center;
+  grid-area: avatar;
+  align-self: center;
 }
 
 .user-menu-button-content > .user-menu-text {
-    grid-row: text / subtext;
+  grid-row: text / subtext;
 }
 
 vaadin-menu-bar[jmix-role='jmix-user-menu'][theme~='substituted'] .user-menu-button-content > .user-menu-text {
-    grid-row: text;
+  grid-row: text;
 }
 
 .user-menu-header-content > .user-menu-text {
-    grid-area: text;
-
-    color: var(--lumo-body-text-color) !important;
-    font-weight: 700;
-    font-size: var(--lumo-font-size-m);
+  grid-area: text;
+  color: var(--lumo-body-text-color) !important;
+  font-weight: 700;
+  font-size: var(--lumo-font-size-m);
 }
 
 .user-menu-header-content > .user-menu-text-subtext {
-    grid-row: text / subtext;
+  grid-row: text / subtext;
 }
 
 .user-menu-button-content > .user-menu-text,
 .user-menu-header-content > .user-menu-text {
-    align-self: center;
-    text-align: start;
-
-    width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  align-self: center;
+  text-align: start;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .user-menu-button-content > .user-menu-subtext,
 .user-menu-header-content > .user-menu-subtext {
-    grid-area: subtext;
-    align-self: center;
-    text-align: start;
-
-    color: var(--lumo-secondary-text-color) !important;
-    font-size: var(--lumo-font-size-xs);
-
-    width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  grid-area: subtext;
+  align-self: center;
+  text-align: start;
+  color: var(--lumo-secondary-text-color) !important;
+  font-size: var(--lumo-font-size-xs);
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 vaadin-menu-bar[jmix-role='jmix-user-menu']:not([theme~='substituted']) .user-menu-button-content > .user-menu-subtext {
-    display: none;
+  display: none;
 }
 
 /* Custom styles */
 .jmix-list-menu {
-    color: var(--lumo-body-text-color);
+  color: var(--lumo-body-text-color);
+  padding: 0.2rem;
 }
 
 .jmix-list-menu a[highlight][class*='jmix-menu-item-link'] {
-    background-color: var(--lumo-primary-color);
-    color: var(--lumo-primary-contrast-color);
-    border-radius: 10px;
+  background: linear-gradient(90deg, var(--lumo-primary-color), color-mix(in srgb, var(--lumo-primary-color) 60%, white));
+  color: var(--lumo-primary-contrast-color);
+  border-radius: var(--lumo-border-radius-m);
+  box-shadow: var(--lumo-box-shadow-xs);
 }
 
 .jmix-list-menu vaadin-details-summary {
-    padding: 0 !important;
+  padding: 0 !important;
 }
 
 .jmix-menubar-item vaadin-details-summary {
-    padding-right: 0.5em !important;
+  padding-right: 0.5em !important;
 }
 
 .jmix-menubar-item vaadin-details-summary:hover {
-    background-color: var(--lumo-primary-color-10pct);
-    color: var(--lumo-primary-text-color);
+  background-color: var(--lumo-primary-color-10pct);
+  color: var(--lumo-primary-text-color);
 }
 
 .jmix-menu-item-link {
-    padding: 0.75rem 0.25rem 0.75rem 0.75rem !important;
+  padding: 0.75rem 0.25rem 0.75rem 0.75rem !important;
+  border-radius: var(--lumo-border-radius-m);
+  transition: background-color 120ms ease, color 120ms ease;
 }
 
 .jmix-menu-item-link span {
-    font-weight: 700 !important;
+  font-weight: 650 !important;
 }
 
 .jmix-menu-item-link:hover {
-    background-color: var(--lumo-primary-color-10pct);
-    color: var(--lumo-primary-text-color);
-    border-radius: 10px;
+  background-color: var(--lumo-primary-color-10pct);
+  color: var(--lumo-primary-text-color);
 }
 
 .jmix-menu-item-link:focus {
-    background-color: var(--lumo-primary-color-50pct);
-    color: var(--lumo-primary-contrast-color);
-    border-radius: 10px;
+  background-color: var(--lumo-primary-color-50pct);
+  color: var(--lumo-primary-contrast-color);
 }
 
 .jmix-menubar-item {
-    color: var(--lumo-body-text-color);
-    padding: 0 !important;
+  color: var(--lumo-body-text-color);
+  padding: 0 !important;
 }
 
 .jmix-menubar-item:focus {
-    background-color: var(--lumo-primary-color);
-    color: var(--lumo-primary-contrast-color);
-    border-radius: 10px;
+  background-color: var(--lumo-primary-color);
+  color: var(--lumo-primary-contrast-color);
+  border-radius: var(--lumo-border-radius-m);
 }
 
 .jmix-menubar-summary-icon-container {
-    box-sizing: border-box;
-    display: flex;
-    align-items: center;
-    gap: var(--lumo-space-s);
-    padding: 0.75rem 0.25rem 0.75rem 0.75rem !important;
-    color: var(--lumo-body-text-color);
-    border-radius: 10px;
-    flex: 1 1 auto;
-    min-width: 0;
-    width: auto !important;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: var(--lumo-space-s);
+  padding: 0.75rem 0.25rem 0.75rem 0.75rem !important;
+  color: var(--lumo-body-text-color);
+  border-radius: var(--lumo-border-radius-m);
+  flex: 1 1 auto;
+  min-width: 0;
+  width: auto !important;
 }


### PR DESCRIPTION
### Motivation
- Refresh the app theme to a more modern, polished look while staying consistent with Vaadin/Lumo and Jmix token conventions. 
- Improve visual hierarchy and readability in both light and dark modes by introducing surface, border and elevation tokens and refining spacing and radii. 

### Description
- Updated core color tokens in `src/main/frontend/themes/crm/colors.css` to a modern primary palette and added reusable tokens (`--crm-surface-color`, `--crm-soft-border-color`, `--crm-elevation-shadow`, and percent variants of primary color) for light and dark themes. 
- Added and adjusted base design tokens in `src/main/frontend/themes/crm/crm.css` for font-family, spacing, border-radius and shadow variables, and moved a subtle page background gradient to this file. 
- Refined Main View shell in `src/main/frontend/themes/crm/view/main-view.css` with a translucent blurred header, softened borders, elevated application title gradient, improved navigation spacing, and refined hover/focus states for menu items. 
- Restyled Login View in `src/main/frontend/themes/crm/view/login-view.css` to use a glass-like form wrapper with border/shadow, token-based input/checkbox colors, a modern CTA gradient, and a richer page background while preserving responsive behavior. 

### Testing
- Ran `./gradlew -q classes` which completed successfully. 
- Launched the application with `./gradlew bootRun` and visually verified the login page; the run completed and the login screen was reachable. 
- Captured a verification screenshot artifact at `browser:/tmp/codex_browser_invocations/4cbd8b9a37c49d52/artifacts/artifacts/modern-theme-login.png` during validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaaede661c83209c4d5130fb972ed1)