### PR TITLE
Fix LocalDateRange.asOffsetDateTimeRange

### DIFF
--- a/src/main/java/com/company/crm/app/util/date/range/LocalDateRange.java
+++ b/src/main/java/com/company/crm/app/util/date/range/LocalDateRange.java
@@ -2,7 +2,7 @@ package com.company.crm.app.util.date.range;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 
 public record LocalDateRange(LocalDate startDate, LocalDate endDate) implements DateRange {
 
@@ -15,8 +15,9 @@ public record LocalDateRange(LocalDate startDate, LocalDate endDate) implements 
     }
 
     public OffsetDateTimeRange asOffsetDateTimeRange() {
-        var offsetStartDate = startDate.atStartOfDay().atOffset(ZoneOffset.UTC);
-        var offsetEndDate = endDate.atStartOfDay().atOffset(ZoneOffset.UTC);
+        var zoneId = ZoneId.systemDefault();
+        var offsetStartDate = startDate.atStartOfDay(zoneId).toOffsetDateTime();
+        var offsetEndDate = endDate.atStartOfDay(zoneId).toOffsetDateTime();
 
         if (startDate.equals(endDate)) {
             offsetEndDate = endOfDay(offsetEndDate);


### PR DESCRIPTION
Root Cause
LocalDateRange.asOffsetDateTimeRange() was hardcoded to ZoneOffset.UTC, but OffsetDateTime.now() (used for createdDate in entities) uses the system timezone (+03:00 in this environment).

Example: 
When the test runs at 2026-06-15T00:25+03:00:

OffsetDateTime.now() = 2026-06-15T00:25+03:00 = 2026-06-14T21:25Z
LocalDate.now() = 2026-06-15
asOffsetDateTimeRange() → [2026-06-15T00:00Z, 2026-06-15T23:59Z] 

2026-06-14T21:25Z < 2026-06-15T00:00Z → outside range → empty results 

Fix
Changed ZoneOffset.UTC → ZoneId.systemDefault()